### PR TITLE
adds a way to correctly import scala-js 0.6 imports

### DIFF
--- a/sbt-twirl/src/main/scala/play/twirl/sbt/SbtTwirl.scala
+++ b/sbt-twirl/src/main/scala/play/twirl/sbt/SbtTwirl.scala
@@ -30,6 +30,12 @@ object SbtTwirl extends AutoPlugin {
 
   val autoImport = Import
 
+  /** if we drop support for scala-js 0.6, this can be finally removed */
+  val isScalaJSProject = SettingKey[Boolean]("isScalaJSProject",
+    "Tests whether the current project is a Scala.js project. " +
+        "Do not set the value of this setting (only use it as read-only).",
+    BSetting)
+
   override def requires = sbt.plugins.JvmPlugin
 
   override def trigger = noTrigger
@@ -75,7 +81,10 @@ object SbtTwirl extends AutoPlugin {
 
   def dependencySettings = Def.settings(
     twirlVersion := readResourceProperty("twirl.version.properties", "twirl.api.version"),
-    libraryDependencies += "com.typesafe.play" %%% "twirl-api" % twirlVersion.value
+    libraryDependencies += {
+      if ((isScalaJSProject ?? false).value) "com.typesafe.play" %% "twirl-api_sjs0.6" % twirlVersion.value
+      else "com.typesafe.play" %%% "twirl-api" % twirlVersion.value
+    }
   )
 
   def scalacEncoding(options: Seq[String]): String = {


### PR DESCRIPTION
Actually this show cases what I meant on top of your branch.

Currently it somehow works and correctly  finds the dependency for scala-js 0.6, 1.0-M1 (and would even recognize scala-native.)
However scala-js 0.6 does not (yet) support `sbt-crossproject`, so the only way to make it work is by trying to get the `isScalaJSProject` variable. Note that: https://gitter.im/sbt/sbt?at=598543d945fc670746f79942 if it is concurrent, it might break, however I do not see that this is the case, (actually I tested it multiple times and it always worked).

However I still think it's preferable to backport support for sbt-crossproject into scala-js 0.6